### PR TITLE
Munik/gem fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.3'
+ruby '2.1.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem 'devise'
 
 # Use AngularJS to make pages more interactive
 gem 'angularjs-rails'
+
+gem 'tzinfo-data'
+
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bootswatch-rails'
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
+gem 'coffee-script-source', '1.8.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
+    coffee-script-source (1.8.0)
     debug_inspector (0.0.2)
     devise (3.5.2)
       bcrypt (~> 3.0)
@@ -166,6 +166,7 @@ DEPENDENCIES
   bootswatch-rails
   byebug
   coffee-rails (~> 4.1.0)
+  coffee-script-source (= 1.8.0)
   devise
   jbuilder (~> 2.0)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2015.7)
+      tzinfo (>= 1.0.0)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -176,6 +178,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring
   turbolinks
+  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 


### PR DESCRIPTION
The first two commits make two changes that I need for it to work on Windows: change Ruby version to 2.1.7 and use 1.8.0 of coffee-script-source. The head commit is a change I needed (in fact -- that the PG gem recommended) when I ran rake db:create db:migrate.
